### PR TITLE
Fix issue with `CurrentDrop` with multiple drops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -826,24 +826,47 @@ end)
 CreateThread(function()
     while true do
         if Drops and next(Drops) then
-            local pos = GetEntityCoords(PlayerPedId(), true)
             for k, v in pairs(Drops) do
                 if Drops[k] then
-                    local dist = #(pos - vector3(v.coords.x, v.coords.y, v.coords.z))
-                    if dist < 7.5 then
+                    local playerCoords = GetEntityCoords(PlayerPedId(), true)
+                    local dropCoords = vector3(v.coords.x, v.coords.y, v.coords.z)
+                    local dist = #(playerCoords - dropCoords)
+                    if dist < 8 then
                         DropsNear[k] = v
-                        if dist < 2 then
-                            CurrentDrop = k
-                        else
-                            CurrentDrop = nil
-                        end
+                        DropsNear[k].dist = dist
                     else
                         DropsNear[k] = nil
                     end
                 end
             end
+            if DropsNear and next(DropsNear) then
+                print("Found near drops")
+                local nearestDropId = nil
+                local min = 3
+                for k, v in pairs(DropsNear) do
+                    if DropsNear[k] then
+                        print("Near drop distance " .. v.dist)
+                        if v.dist < 2 then
+                            if v.dist < min then
+                                print("Setting new near drop min")
+                                min = v.dist
+                                nearestDropId = k
+                            end
+                        end
+                    end
+                end
+                if nearestDropId then
+                    CurrentDrop = nearestDropId
+                else
+                    CurrentDrop = nil
+                end
+            else
+                print("No near drops")
+                CurrentDrop = nil
+            end
         else
             DropsNear = {}
+            CurrentDrop = nil
         end
         Wait(500)
     end


### PR DESCRIPTION
There is an issue with the `CurrentDrop` assignment when there is more than one near drop visible. `CurrentDrop` is always set to `nil` if there are multiple elements in the `DropsNear` table and the player is not close enough to the first element. 

To reproduce it, drop to items at close range, but not in the same drop. Now check to see if you can access both of them successfully.

The new version of the script will loop through all the `Drops`, then find all the `DropsNear` elements, and then set the `CurrentDrop` to the ID that is closest to the current player location. Tested it locally while creating drops from dead NPCs and it seems to work better. 

Feel free to change it as you see fit or comment on this PR if you have any suggestions.
Thanks!